### PR TITLE
Bump version to 0.2.0 and add code examples

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,9 @@ name: Build and Test
 on:
   push:
     branches: [ main ]
-  workflow_dispatch: # manually trigger the workflow
+  pull_request:
+    branches: [ main ]  # on pull requests to main branch
+  workflow_dispatch:    # manually trigger the workflow
 
 permissions:
   checks: write

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,6 +78,28 @@
             "externalConsole": false
         },
         {
+            "name": "(Windows) tiff_image_example",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${command:cmake.buildDirectory}/bin/tiff_image_example.exe",
+            "args": ["tests/libtiff-pics/jim___ah.tif"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "(Windows) tiff_exporter_example",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${command:cmake.buildDirectory}/bin/tiff_exporter_example.exe",
+            "args": ["tests/libtiff-pics/jim___ah.tif"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Python Debugger: Current File",
             "type": "debugpy",
             "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
     MINOR version when you add functionality in a backward compatible manner.
     PATCH version when you make backward compatible bug fixes.
 
-## [Unreleased]
+## [0.2.0-Unreleased]
+
+### Added
+
+- Code examples
+
+## [0.1.0]
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,5 +39,6 @@ install(DIRECTORY include/ DESTINATION include)
 enable_testing()
 add_subdirectory(tests)
 
-# Build apps
+# Build apps and code examples
 add_subdirectory(apps)
+add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_executable(tiff_image_example tiff_image.cpp)
+target_link_libraries(tiff_image_example PRIVATE TiffCraft)
+
+add_executable(tiff_exporter_example tiff_exporter.cpp)
+target_link_libraries(tiff_exporter_example PRIVATE TiffCraft)

--- a/examples/tiff_exporter.cpp
+++ b/examples/tiff_exporter.cpp
@@ -1,0 +1,58 @@
+// BSD 2-Clause License
+// Copyright (c) 2025 Daniel Moreno
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------------
+//
+// tiff_exporter.cpp
+// =================
+// This is a minimal code example of how to use exporters.
+//
+
+#include <tiffcraft/TiffExporter.hpp>
+#include <functional>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <image.tiff>" << std::endl;
+    return 1;
+  }
+
+  std::cout << "TiffCraft version " << TiffCraft::version() << std::endl;
+  std::cout << "Loading image: " << argv[1] << std::endl;
+
+  TiffCraft::TiffExporterAny tiffExporter;
+  TiffCraft::load(argv[1], std::ref(tiffExporter));
+  auto image = tiffExporter.takeImage();
+
+  std::cout << "Exported image: " << image.width << "x" << image.height
+            << ", " << image.channels << " channels, "
+            << image.bitDepth << " bits per sample, "
+            << image.dataSize() << " bytes of pixel data."
+            << std::endl;
+
+  // your own image processing code
+
+  return 0;
+}

--- a/examples/tiff_image.cpp
+++ b/examples/tiff_image.cpp
@@ -1,0 +1,69 @@
+// BSD 2-Clause License
+// Copyright (c) 2025 Daniel Moreno
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------------
+//
+// tiff_image.cpp
+// ==============
+// This is a minimal code example of how to use `TiffCraft::load()`.
+//
+
+#include <tiffcraft/TiffImage.hpp>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <image.tiff>" << std::endl;
+    return 1;
+  }
+
+  std::cout << "TiffCraft version " << TiffCraft::version() << std::endl;
+  std::cout << "Loading image: " << argv[1] << std::endl;
+
+  TiffCraft::load(argv[1],
+    [](const TiffCraft::TiffImage::Header& header,
+        const TiffCraft::TiffImage::IFD& ifd,
+        TiffCraft::TiffImage::ImageData imageData) {
+      std::cout << "Loaded IFD with " << ifd.entries().size()
+                << " entries." << std::endl;
+
+      size_t totalBytes = 0;
+      for (const auto& vec : imageData) {
+          totalBytes += vec.size();
+      }
+      std::cout << "Image data bytes: " << totalBytes << std::endl;
+
+      std::cout << "Image width: "
+                << ifd.getEntry(TiffCraft::Tag::ImageWidth).values<uint16_t>()[0]
+                << std::endl;
+      std::cout << "Image height: "
+                << ifd.getEntry(TiffCraft::Tag::ImageLength).values<uint16_t>()[0]
+                << std::endl;
+
+      // Add your own image processing code here
+
+    });
+
+  return 0;
+}

--- a/include/tiffcraft/TiffExporter.hpp
+++ b/include/tiffcraft/TiffExporter.hpp
@@ -40,8 +40,8 @@
 //     int main(int argc, char* argv[]) {
 //       if (argc < 2) { return 1; }
 //       TiffCraft::TiffExporterAny tiffExporter;
-//       TiffCraft::load(argv[1], std::ref(tiffExporter), loadParams);
-//       auto image = iffExporter.takeImage();
+//       TiffCraft::load(argv[1], std::ref(tiffExporter));
+//       auto image = tiffExporter.takeImage();
 //
 //       // your own image processing code
 //

--- a/include/tiffcraft/TiffImage.hpp
+++ b/include/tiffcraft/TiffImage.hpp
@@ -94,7 +94,7 @@ namespace TiffCraft {
 
   // TiffCraft version
   constexpr int MAJOR_VERSION = 0;
-  constexpr int MINOR_VERSION = 1;
+  constexpr int MINOR_VERSION = 2;
   constexpr int PATCH_VERSION = 0;
 
   std::string version() {


### PR DESCRIPTION
Add code examples to validate the code in the header documentation for "TiffImage.hpp" and "TiffExporter.hpp"