### PR TITLE
Add cmake preset for win64 ninja (Fixes #10)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-2025
 
     env:
-      PRESET_NAME: msvc-win64-release
+      PRESET_NAME: msvc-win64-ninja-release
 
     steps:
     - name: Checkout source code
@@ -50,6 +50,9 @@ jobs:
 
     - name: Checkout submodules
       run: git submodule update --init --recursive
+
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Cmake configure
       run: cmake --preset ${{ env.PRESET_NAME }} ${{ env.CMAKE_CONFIG_OPTIONS }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,16 +53,13 @@
       "name": "msvc-win64",
       "hidden": true,
       "inherits": ["win64"],
-      "generator": "Visual Studio 17 2022",
-      "toolset": "host=x64",
-      "architecture": "x64",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",
         "CMAKE_CXX_COMPILER": "cl.exe"
       }
     },
     {
-      "name": "clang-unix-make",
+      "name": "clang-unix",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/usr/bin/clang",
@@ -70,7 +67,7 @@
       }
     },
     {
-      "name": "gcc-unix-make",
+      "name": "gcc-unix",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/usr/bin/gcc",
@@ -78,9 +75,11 @@
       }
     },
     {
-      "name": "makefile",
+      "name": "vs17",
       "hidden": true,
-      "generator": "Unix Makefiles"
+      "generator": "Visual Studio 17 2022",
+      "toolset": "host=x64",
+      "architecture": "x64"
     },
     {
       "name": "ninja",
@@ -88,27 +87,50 @@
       "generator": "Ninja"
     },
     {
+      "name": "make",
+      "hidden": true,
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "msvc-win64-vs17",
+      "hidden": true,
+      "inherits": ["msvc-win64","vs17"]
+    },
+    {
+      "name": "msvc-win64-ninja",
+      "hidden": true,
+      "inherits": ["msvc-win64","ninja"]
+    },
+    {
       "name": "clang-macos-make",
       "hidden": true,
-      "inherits": ["clang-unix-make","macos","makefile"]
+      "inherits": ["clang-unix","macos","make"]
     },
     {
       "name": "gcc-linux-make",
       "hidden": true,
-      "inherits": ["gcc-unix-make","linux","makefile"]
+      "inherits": ["gcc-unix","linux","make"]
     },
     {
       "name": "gcc-linux-ninja",
       "hidden": true,
-      "inherits": ["gcc-unix-make","linux","ninja"]
+      "inherits": ["gcc-unix","linux","ninja"]
     },
     {
       "name": "msvc-win64-debug",
-      "inherits": ["msvc-win64","debug-config"]
+      "inherits": ["msvc-win64-vs17","debug-config"]
     },
     {
       "name": "msvc-win64-release",
-      "inherits": ["msvc-win64","release-config"]
+      "inherits": ["msvc-win64-vs17","release-config"]
+    },
+    {
+      "name": "msvc-win64-ninja-debug",
+      "inherits": ["msvc-win64-ninja","debug-config"]
+    },
+    {
+      "name": "msvc-win64-ninja-release",
+      "inherits": ["msvc-win64-ninja","release-config"]
     },
     {
       "name": "clang-macos-debug",
@@ -147,6 +169,16 @@
       "configurePreset": "msvc-win64-release",
       "configuration": "Release",
       "jobs": 4
+    },
+    {
+      "name": "msvc-win64-ninja-debug",
+      "configurePreset": "msvc-win64-ninja-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "msvc-win64-ninja-release",
+      "configurePreset": "msvc-win64-ninja-release",
+      "configuration": "Release"
     },
     {
       "name": "clang-macos-debug",
@@ -188,6 +220,16 @@
     {
       "name": "msvc-win64-release",
       "configurePreset": "msvc-win64-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "msvc-win64-ninja-debug",
+      "configurePreset": "msvc-win64-ninja-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "msvc-win64-ninja-release",
+      "configurePreset": "msvc-win64-ninja-release",
       "configuration": "Release"
     },
     {


### PR DESCRIPTION
Update GitHub workflow

- Build with the new preset
- Use `ilammy/msvc-dev-cmd@v1` action to setup a MSVC development environment

GitHub action for Windows runner went down from ~3 minutes to ~1 minute with this change.