### PR TITLE
Disable deprecation warning for tiff_exporter app on macOS

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,7 @@
 
 add_executable(tiff_exporter tiff_exporter.cpp)
 target_link_libraries(tiff_exporter PRIVATE TiffCraft)
+
+if (APPLE)
+  target_compile_options(tiff_exporter PRIVATE -Wno-deprecated-declarations)
+endif()


### PR DESCRIPTION
There was a compile warning for clang in macOS build due `stb_image_write.h` trying to use `sprintf()` which has no bounds check.

Fixes #13