### PR TITLE
Add Ninja macOS presets (Fixes #14)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-15
 
     env:
-      PRESET_NAME: clang-macos-release
+      PRESET_NAME: clang-macos-ninja-release
 
     steps:
     - name: Checkout source code

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,6 +107,11 @@
       "inherits": ["clang-unix","macos","make"]
     },
     {
+      "name": "clang-macos-ninja",
+      "hidden": true,
+      "inherits": ["clang-unix","macos","ninja"]
+    },
+    {
       "name": "gcc-linux-make",
       "hidden": true,
       "inherits": ["gcc-unix","linux","make"]
@@ -139,6 +144,14 @@
     {
       "name": "clang-macos-release",
       "inherits": ["clang-macos-make","release-config"]
+    },
+    {
+      "name": "clang-macos-ninja-debug",
+      "inherits": ["clang-macos-ninja","debug-config"]
+    },
+    {
+      "name": "clang-macos-ninja-release",
+      "inherits": ["clang-macos-ninja","release-config"]
     },
     {
       "name": "gcc-linux-debug",
@@ -191,6 +204,16 @@
       "configuration": "Release"
     },
     {
+      "name": "clang-macos-ninja-debug",
+      "configurePreset": "clang-macos-ninja-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "clang-macos-ninja-release",
+      "configurePreset": "clang-macos-ninja-release",
+      "configuration": "Release"
+    },
+    {
       "name": "gcc-linux-debug",
       "configurePreset": "gcc-linux-debug",
       "configuration": "Debug"
@@ -240,6 +263,16 @@
     {
       "name": "clang-macos-release",
       "configurePreset": "clang-macos-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "clang-macos-ninja-debug",
+      "configurePreset": "clang-macos-ninja-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "clang-macos-ninja-release",
+      "configurePreset": "clang-macos-ninja-release",
       "configuration": "Release"
     },
     {


### PR DESCRIPTION
Set the Ninja preset as the selected one in the workflow.

Build time for macOS runner uses to take up to 15 minutes sometimes. After switching to Ninja preset is now less than 1 minute.